### PR TITLE
✨ feat: ThemeProvider 및 GlobalStyle 생성

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,18 @@
 import { useEffect, useState } from "react";
+import styled, { ThemeProvider } from "styled-components";
+import { GlobalStyle } from ".";
+import { darkTheme, lightTheme } from "./theme";
 import Ads from "./components/Ads";
 import BoardMain from "./components/BoardMain";
 
+const Container = styled.div`
+  color: ${(props) => props.theme.textColor};
+  background-color: ${(props) => props.theme.bgColor};
+`;
+
 function App() {
   const [freeItems, setFreeItems] = useState([]);
+  const [isDark, setIsDark] = useState(false);
   useEffect(() => {
     fetch("http://localhost:3001/vote")
       .then((res) => res.json())
@@ -11,10 +20,13 @@ function App() {
       .catch((e) => console.log(e));
   }, []);
   return (
-    <div className="App">
-      <BoardMain items={freeItems} />
-      <Ads />
-    </div>
+    <ThemeProvider theme={isDark ? darkTheme : lightTheme}>
+      <GlobalStyle />
+      <Container>
+        <BoardMain items={freeItems} />
+        <Ads />
+      </Container>
+    </ThemeProvider>
   );
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,58 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { createGlobalStyle } from "styled-components";
 import App from "./App";
+
+export const GlobalStyle = createGlobalStyle`
+  /* http://meyerweb.com/eric/tools/css/reset/ 
+   v2.0 | 20110126
+   License: none (public domain)
+*/
+
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, 
+figure, figcaption, footer, header, hgroup, 
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure, 
+footer, header, hgroup, menu, nav, section {
+	display: block;
+}
+body {
+	line-height: 1;
+}
+ol, ul {
+	list-style: none;
+}
+blockquote, q {
+	quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
+}
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
+}
+`;
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,9 @@
+export const lightTheme = {
+  bgColor: "white",
+  textColor: "black",
+};
+
+export const darkTheme = {
+  bgColor: "black",
+  textColor: "white",
+};


### PR DESCRIPTION
# Styled-Components 세팅

## GlobalStyle

- 우선 좀 오래된 코드이긴한데 [Eric Meyer’s “Reset CSS” 2.0](https://cssdeck.com/blog/scripts/eric-meyer-reset-css/) 에서 가져왔고 추후 변경 가능합니다.

## ThemeProvider

- 아직 스타일적인 부분(색상)은 정해지지 않아서` darkTheme = { bgColor : "black", textColor: "white" }, lightTheme = { textColor : "white", bgColor: "black" }` 만 주었습니다.
- theme.js 에서 해당 색상 이용하실때 styled-components css 설정 안에서 `${props => props.theme.bgColor}` of `${props => props.theme.textColor}` 형식으로 사용하시면 됩니다.