### PR TITLE
🍖 10월 22일 작업분

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -8,7 +8,8 @@
       "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
       "createdAt": "약 2개월 전",
       "likes": 25,
-      "comments": 14
+      "comments": 14,
+      "tags": ["컴퓨터과학", "추천도서"]
     },
     {
       "id": 2,
@@ -17,7 +18,8 @@
       "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
       "createdAt": "약 2개월 전",
       "likes": 25,
-      "comments": 14
+      "comments": 14,
+      "tags": ["컴퓨터과학", "추천도서"]
     },
     {
       "id": 3,
@@ -26,7 +28,8 @@
       "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
       "createdAt": "약 2개월 전",
       "likes": 25,
-      "comments": 14
+      "comments": 14,
+      "tags": ["컴퓨터과학", "추천도서"]
     },
     {
       "id": 4,
@@ -35,7 +38,8 @@
       "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
       "createdAt": "약 2개월 전",
       "likes": 25,
-      "comments": 14
+      "comments": 14,
+      "tags": ["컴퓨터과학", "추천도서"]
     },
     {
       "id": 5,
@@ -44,7 +48,8 @@
       "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
       "createdAt": "약 2개월 전",
       "likes": 25,
-      "comments": 14
+      "comments": 14,
+      "tags": ["컴퓨터과학", "추천도서"]
     },
     {
       "id": 6,
@@ -53,7 +58,8 @@
       "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
       "createdAt": "약 2개월 전",
       "likes": 25,
-      "comments": 14
+      "comments": 14,
+      "tags": ["컴퓨터과학", "추천도서"]
     },
     {
       "id": 7,
@@ -62,7 +68,8 @@
       "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
       "createdAt": "약 2개월 전",
       "likes": 25,
-      "comments": 14
+      "comments": 14,
+      "tags": ["컴퓨터과학", "추천도서"]
     },
     {
       "id": 8,
@@ -71,7 +78,8 @@
       "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
       "createdAt": "약 2개월 전",
       "likes": 25,
-      "comments": 14
+      "comments": 14,
+      "tags": ["컴퓨터과학", "추천도서"]
     },
     {
       "id": 9,
@@ -80,7 +88,8 @@
       "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
       "createdAt": "약 2개월 전",
       "likes": 25,
-      "comments": 14
+      "comments": 14,
+      "tags": ["컴퓨터과학", "추천도서"]
     },
     {
       "id": 10,
@@ -89,7 +98,8 @@
       "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
       "createdAt": "약 2개월 전",
       "likes": 25,
-      "comments": 14
+      "comments": 14,
+      "tags": ["컴퓨터과학", "추천도서"]
     },
     {
       "id": 11,
@@ -98,7 +108,8 @@
       "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
       "createdAt": "약 2개월 전",
       "likes": 25,
-      "comments": 14
+      "comments": 14,
+      "tags": ["컴퓨터과학", "추천도서"]
     },
     {
       "id": 12,
@@ -107,7 +118,8 @@
       "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
       "createdAt": "약 2개월 전",
       "likes": 25,
-      "comments": 14
+      "comments": 14,
+      "tags": ["컴퓨터과학", "추천도서"]
     },
     {
       "id": 13,
@@ -116,7 +128,8 @@
       "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
       "createdAt": "약 2개월 전",
       "likes": 25,
-      "comments": 14
+      "comments": 14,
+      "tags": ["컴퓨터과학", "추천도서"]
     },
     {
       "id": 14,
@@ -125,7 +138,8 @@
       "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
       "createdAt": "약 2개월 전",
       "likes": 25,
-      "comments": 14
+      "comments": 14,
+      "tags": ["컴퓨터과학", "추천도서"]
     },
     {
       "id": 15,
@@ -134,7 +148,8 @@
       "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
       "createdAt": "약 2개월 전",
       "likes": 25,
-      "comments": 14
+      "comments": 14,
+      "tags": ["컴퓨터과학", "추천도서"]
     },
     {
       "id": 16,
@@ -143,7 +158,8 @@
       "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
       "createdAt": "약 2개월 전",
       "likes": 25,
-      "comments": 14
+      "comments": 14,
+      "tags": ["컴퓨터과학", "추천도서"]
     },
     {
       "id": 17,
@@ -152,7 +168,8 @@
       "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
       "createdAt": "약 2개월 전",
       "likes": 25,
-      "comments": 14
+      "comments": 14,
+      "tags": ["컴퓨터과학", "추천도서"]
     },
     {
       "id": 18,
@@ -161,7 +178,8 @@
       "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
       "createdAt": "약 2개월 전",
       "likes": 25,
-      "comments": 14
+      "comments": 14,
+      "tags": ["컴퓨터과학", "추천도서"]
     },
     {
       "id": 19,
@@ -170,7 +188,8 @@
       "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
       "createdAt": "약 2개월 전",
       "likes": 25,
-      "comments": 14
+      "comments": 14,
+      "tags": ["컴퓨터과학", "추천도서"]
     },
     {
       "id": 20,
@@ -179,7 +198,8 @@
       "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
       "createdAt": "약 2개월 전",
       "likes": 25,
-      "comments": 14
+      "comments": 14,
+      "tags": ["컴퓨터과학", "추천도서"]
     }
   ],
   "popularTags": [

--- a/data/data.json
+++ b/data/data.json
@@ -1,52 +1,187 @@
 {
-  "vote": [
-    
+  "vote": [],
+  "free": [
+    {
+      "id": 1,
+      "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
+      "author": "운체조교",
+      "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
+      "createdAt": "약 2개월 전",
+      "likes": 25,
+      "comments": 14
+    },
+    {
+      "id": 2,
+      "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
+      "author": "운체조교",
+      "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
+      "createdAt": "약 2개월 전",
+      "likes": 25,
+      "comments": 14
+    },
+    {
+      "id": 3,
+      "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
+      "author": "운체조교",
+      "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
+      "createdAt": "약 2개월 전",
+      "likes": 25,
+      "comments": 14
+    },
+    {
+      "id": 4,
+      "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
+      "author": "운체조교",
+      "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
+      "createdAt": "약 2개월 전",
+      "likes": 25,
+      "comments": 14
+    },
+    {
+      "id": 5,
+      "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
+      "author": "운체조교",
+      "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
+      "createdAt": "약 2개월 전",
+      "likes": 25,
+      "comments": 14
+    },
+    {
+      "id": 6,
+      "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
+      "author": "운체조교",
+      "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
+      "createdAt": "약 2개월 전",
+      "likes": 25,
+      "comments": 14
+    },
+    {
+      "id": 7,
+      "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
+      "author": "운체조교",
+      "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
+      "createdAt": "약 2개월 전",
+      "likes": 25,
+      "comments": 14
+    },
+    {
+      "id": 8,
+      "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
+      "author": "운체조교",
+      "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
+      "createdAt": "약 2개월 전",
+      "likes": 25,
+      "comments": 14
+    },
+    {
+      "id": 9,
+      "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
+      "author": "운체조교",
+      "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
+      "createdAt": "약 2개월 전",
+      "likes": 25,
+      "comments": 14
+    },
+    {
+      "id": 10,
+      "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
+      "author": "운체조교",
+      "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
+      "createdAt": "약 2개월 전",
+      "likes": 25,
+      "comments": 14
+    },
+    {
+      "id": 11,
+      "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
+      "author": "운체조교",
+      "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
+      "createdAt": "약 2개월 전",
+      "likes": 25,
+      "comments": 14
+    },
+    {
+      "id": 12,
+      "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
+      "author": "운체조교",
+      "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
+      "createdAt": "약 2개월 전",
+      "likes": 25,
+      "comments": 14
+    },
+    {
+      "id": 13,
+      "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
+      "author": "운체조교",
+      "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
+      "createdAt": "약 2개월 전",
+      "likes": 25,
+      "comments": 14
+    },
+    {
+      "id": 14,
+      "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
+      "author": "운체조교",
+      "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
+      "createdAt": "약 2개월 전",
+      "likes": 25,
+      "comments": 14
+    },
+    {
+      "id": 15,
+      "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
+      "author": "운체조교",
+      "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
+      "createdAt": "약 2개월 전",
+      "likes": 25,
+      "comments": 14
+    },
+    {
+      "id": 16,
+      "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
+      "author": "운체조교",
+      "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
+      "createdAt": "약 2개월 전",
+      "likes": 25,
+      "comments": 14
+    },
+    {
+      "id": 17,
+      "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
+      "author": "운체조교",
+      "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
+      "createdAt": "약 2개월 전",
+      "likes": 25,
+      "comments": 14
+    },
+    {
+      "id": 18,
+      "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
+      "author": "운체조교",
+      "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
+      "createdAt": "약 2개월 전",
+      "likes": 25,
+      "comments": 14
+    },
+    {
+      "id": 19,
+      "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
+      "author": "운체조교",
+      "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
+      "createdAt": "약 2개월 전",
+      "likes": 25,
+      "comments": 14
+    },
+    {
+      "id": 20,
+      "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
+      "author": "운체조교",
+      "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
+      "createdAt": "약 2개월 전",
+      "likes": 25,
+      "comments": 14
+    }
   ],
-  "free": [{
-    "id": 1,
-    "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
-    "author": "운체조교",
-    "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
-    "createdAt": "약 2개월 전",
-    "likes": 25,
-    "comments": 14
-  },
-  {
-    "id": 2,
-    "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
-    "author": "운체조교",
-    "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
-    "createdAt": "약 2개월 전",
-    "likes": 25,
-    "comments": 14
-  },
-  {
-    "id": 3,
-    "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
-    "author": "운체조교",
-    "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
-    "createdAt": "약 2개월 전",
-    "likes": 25,
-    "comments": 14
-  },
-  {
-    "id": 4,
-    "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
-    "author": "운체조교",
-    "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
-    "createdAt": "약 2개월 전",
-    "likes": 25,
-    "comments": 14
-  },
-  {
-    "id": 5,
-    "title": "컴퓨터과학의 역사가 궁금하신 분들을 위한 추천도서",
-    "author": "운체조교",
-    "authorAvatar": "https://www.gravatar.com/avatar/9a316994cda85c56cd4f0c833ec511b6?d=identicon&s=96",
-    "createdAt": "약 2개월 전",
-    "likes": 25,
-    "comments": 14
-  }],
   "popularTags": [
     { "name": "java", "point": 40 },
     { "name": "javascript", "point": 29 },

--- a/src/App.js
+++ b/src/App.js
@@ -2,8 +2,10 @@ import { useState } from "react";
 import { ThemeProvider } from "styled-components";
 import { GlobalStyle } from ".";
 import { darkTheme, lightTheme } from "./theme";
-import Home from "./pages/Home";
 import { useSelector } from "react-redux";
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import Home from "./pages/Home";
+import Login from "./pages/Login";
 
 function App() {
   const [freeItems, setFreeItems] = useState([]);
@@ -11,7 +13,15 @@ function App() {
   return (
     <ThemeProvider theme={isDark ? darkTheme : lightTheme}>
       <GlobalStyle />
-      <Home freeItems={freeItems} setFreeItems={setFreeItems} />
+      <Router>
+        <Routes>
+          <Route
+            path="/"
+            element={<Home freeItems={freeItems} setFreeItems={setFreeItems} />}
+          />
+          <Route path="/login" element={<Login />} />
+        </Routes>
+      </Router>
     </ThemeProvider>
   );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ThemeProvider } from "styled-components";
 import { GlobalStyle } from ".";
 import { darkTheme, lightTheme } from "./theme";
@@ -6,20 +6,25 @@ import { useSelector } from "react-redux";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Home from "./pages/Home";
 import Login from "./pages/Login";
+import Board from "./pages/Board";
 
 function App() {
   const [freeItems, setFreeItems] = useState([]);
   const isDark = useSelector((state) => state.isDark.value);
+  useEffect(() => {
+    fetch("http://localhost:3001/free")
+      .then((res) => res.json())
+      .then((data) => setFreeItems(data))
+      .catch((e) => console.log(e));
+  }, []);
   return (
     <ThemeProvider theme={isDark ? darkTheme : lightTheme}>
       <GlobalStyle />
       <Router>
         <Routes>
-          <Route
-            path="/"
-            element={<Home freeItems={freeItems} setFreeItems={setFreeItems} />}
-          />
+          <Route path="/" element={<Home freeItems={freeItems} />} />
           <Route path="/login" element={<Login />} />
+          <Route path="/board" element={<Board freeItems={freeItems} />} />
         </Routes>
       </Router>
     </ThemeProvider>

--- a/src/components/BoardMain.js
+++ b/src/components/BoardMain.js
@@ -1,6 +1,7 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { regular } from "@fortawesome/fontawesome-svg-core/import.macro";
 import styled from "styled-components";
+import { useEffect, useState } from "react";
 
 const StyledBoard = styled.div`
   width: 35vw;
@@ -59,13 +60,17 @@ const StyledBoard = styled.div`
 `;
 
 const BoardMain = ({ items }) => {
+  const [itemsForMain, setItemsForMain] = useState([]);
+  useEffect(() => {
+    setItemsForMain(items.slice(0, 5));
+  }, []);
   return (
     <StyledBoard className="BoardMain">
       <div className="board-title">
         <h2 className="board-title-name">투표 게시판</h2>
       </div>
       <ul className="items-containter">
-        {items.map((item) => (
+        {itemsForMain.map((item) => (
           <li className="item" key={item.id}>
             <div className="item-detail">
               <div className="about-author">

--- a/src/components/header/AuthBtn.js
+++ b/src/components/header/AuthBtn.js
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { Link } from "react-router-dom";
 
 const Wrapper = styled.div`
   display: flex;
@@ -21,7 +22,9 @@ const JoinBtn = styled(LoginBtn)`
 function AuthBtn() {
   return (
     <Wrapper>
-      <LoginBtn>Login</LoginBtn>
+      <Link to="/login">
+        <LoginBtn>Login</LoginBtn>
+      </Link>
       <JoinBtn>Join</JoinBtn>
     </Wrapper>
   );

--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { Link } from "react-router-dom";
 import AuthBtn from "./AuthBtn";
 import DarkModeBtn from "./DarkModeBtn";
 import Search from "./Search";
@@ -31,7 +32,9 @@ function Header() {
   return (
     <Container>
       <Nav>
-        <HomeBtn>GoHome</HomeBtn>
+        <Link to="/">
+          <HomeBtn>GoHome</HomeBtn>
+        </Link>
         <Ul>
           <Li>Screen 1</Li>
           <Li>Screen 2</Li>

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -20,7 +20,6 @@ const Main = styled.main`
   width: 100vw;
   display: flex;
   justify-content: space-around;
-  align-items: center;
 `;
 
 function Home({ freeItems }) {

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -23,14 +23,7 @@ const Main = styled.main`
   align-items: center;
 `;
 
-function Home({ freeItems, setFreeItems }) {
-  useEffect(() => {
-    fetch("http://localhost:3001/free")
-      .then((res) => res.json())
-      .then((data) => setFreeItems(data))
-      .catch((e) => console.log(e));
-  }, []);
-
+function Home({ freeItems }) {
   return (
     <Container>
       <Header />


### PR DESCRIPTION
## React-Router-Dom 적용

- 이전까지 작업했던 Home, Login 페이지에 React-Router-Dom 으로 연결하였습니다.
- 추가로 작업할 페이지들도 App.js 에서 Route 컴포넌트를 사용해서 연결하며 작업하면 될 것 같습니다.

## data.json 수정

- 글 목록 레이아웃을 구현하기 위해서 /free 데이터의 갯수를 20개로 늘려줬습니다.

## Slice items in BoardMain 컴포넌트

- /free 데이터의 갯수가 20개로 늘었는데 BoardMain 컴포넌트 에서 필요한 items 는 5개라 배열을 slice 해주었습니다.

## /free Data Fetch 위치 변경

- 게시판 글목록 작업을 하면서 기존 Home 페이지에서 사용했던 /free 데이터와 같은 데이터를 사용할 건데, Home 과 글목록 작업 페이지인 Board 페이지가 형제관계라 props 전달이 안되므로 App.js 로 데이터 페칭 위치를 변경했습니다.

## Home 페이지의 Main 컴포넌트 `align-items: center` 속성 삭제

- 메인에서 글 목록이 아닌 각 탭에서의(Board 페이지) 글목록은 훨씬 길기 때문에 해당 속성이 있는 경우 Aside 와 Ads 컴포넌트의 위치가 Home 페이지 에서와 다르게 됩니다.
  - 코드 통일성을 위해 글목록, 글작성 등이 들어갈 Board 페이지에서도 동일하게 `align-items: center` 없이 작성하겠습니다.

## Data free 의 Object 에 tags 페어 추가

- 글 목록에서 태그 보여주는 부분이 있어서 추가했습니다.