### PR TITLE
🍖 10월 23일 작업분

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,8 @@ import { useSelector } from "react-redux";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Home from "./pages/Home";
 import SignInAndUp from "./pages/SignInAndUp";
-import Board from "./pages/Board";
+import BoardList from "./pages/BoardList";
+import BoardWrite from "./pages/BoardWrite";
 import Profile from "./components/Profile";
 
 function App() {
@@ -19,7 +20,8 @@ function App() {
           <Route path="/" element={<Home />} />
           <Route path="/login" element={<SignInAndUp />} />
           <Route path="/join" element={<SignInAndUp />} />
-          <Route path="/board" element={<Board />} />
+          <Route path="/board" element={<BoardList />} />
+          <Route path="/write" element={<BoardWrite />} />
           <Route path="/profile" element={<Profile />} />
         </Routes>
       </Router>

--- a/src/components/board/List.js
+++ b/src/components/board/List.js
@@ -2,6 +2,9 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { regular } from "@fortawesome/fontawesome-svg-core/import.macro";
 import styled from "styled-components";
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { BtnAccent } from "../button/BtnAccent";
+import { BtnDefault } from "../button/BtnDefault";
 
 const StyledBoard = styled.div`
   width: 70vw;
@@ -25,35 +28,6 @@ const StyledBoard = styled.div`
     display: flex;
     justify-content: space-between;
     align-items: center;
-
-    button {
-      height: 50px;
-      padding: 0 20px;
-      border-radius: 10px;
-      font-size: 18px;
-    }
-
-    button:first-child {
-      color: ${(props) => props.theme.bgColor};
-      background-color: ${(props) => props.theme.accentColor};
-      border: none;
-
-      &:hover {
-        background-color: ${(props) => props.theme.accentColorOpacity};
-        cursor: pointer;
-      }
-    }
-
-    button:last-child {
-      border: 1px solid ${(props) => props.theme.textColor};
-      color: ${(props) => props.theme.textColor};
-      background-color: ${(props) => props.theme.bgColor};
-
-      &:hover {
-        background-color: ${(props) => props.theme.bgColorOpacity};
-        cursor: pointer;
-      }
-    }
 
     .board-tab {
       display: flex;
@@ -248,14 +222,16 @@ const List = ({ path }) => {
         <h2 className="board-title-name">투표 게시판</h2>
       </div>
       <div className="board-util">
-        <button>✏️ 작성하기</button>
+        <Link to="/write">
+          <BtnAccent>✏️ 작성하기</BtnAccent>
+        </Link>
         <ul className="board-tab">
           <li>기술</li>
           <li>커리어</li>
           <li>기타</li>
           <li>전체</li>
         </ul>
-        <button>⬇️ 최신순</button>
+        <BtnDefault>⬇️ 최신순</BtnDefault>
       </div>
       <hr />
       <div className="board-list-util">

--- a/src/components/board/Write.js
+++ b/src/components/board/Write.js
@@ -1,0 +1,107 @@
+import styled from "styled-components";
+import { BtnAccent } from "../button/BtnAccent";
+import { BtnDefault } from "../button/BtnDefault";
+
+const StyledBoard = styled.div`
+  width: 70vw;
+`;
+
+const Header = styled.header`
+  width: 70vw;
+  height: 110px;
+
+  h1 {
+    padding-top: 30px;
+    padding-bottom: 20px;
+    font-size: 36px;
+    font-weight: 500;
+  }
+
+  span:first-child {
+    font-weight: bold;
+  }
+
+  span:last-child {
+    color: ${(props) => props.theme.textColorOpacity};
+  }
+`;
+
+const WriteForm = styled.form`
+  height: 1000px;
+  display: flex;
+  flex-direction: column;
+  font-size: 18px;
+
+  select {
+    height: 50px;
+    font-size: 18px;
+    padding-left: 10px;
+    border-radius: 10px;
+    border: 1px solid ${(props) => props.theme.textColorOpacity};
+  }
+
+  label {
+    margin-bottom: 10px;
+    margin-top: 50px;
+  }
+
+  input {
+    height: 50px;
+    font-size: 18px;
+    padding-left: 10px;
+    border-radius: 10px;
+    border: 1px solid ${(props) => props.theme.textColorOpacity};
+  }
+
+  textarea {
+    resize: none;
+    height: 400px;
+    font-size: 18px;
+    padding-left: 10px;
+    padding-top: 20px;
+    margin-bottom: 50px;
+    border-radius: 10px;
+    border: 1px solid ${(props) => props.theme.textColorOpacity};
+  }
+
+  div {
+    display: flex;
+    justify-content: flex-end;
+    gap: 20px;
+  }
+`;
+
+const Write = () => {
+  return (
+    <StyledBoard className="BoardMain">
+      <Header>
+        <h1>함께 할 때 더 즐거운 순간</h1>
+        <span>박연우</span>
+        <span>
+          님 지식공유 플랫폼 OKKY에서 다양한 사람을 만나고 생각의 폭을
+          넓혀보세요.
+        </span>
+      </Header>
+      <WriteForm>
+        <label for="topic">토픽</label>
+        <select id="topic">
+          <option>토픽을 선택해주세요.</option>
+          <option>사는얘기</option>
+          <option>모임&스터디</option>
+        </select>
+        <label for="title">제목</label>
+        <input id="title" placeholder="제목을 입력해주세요." />
+        <label for="tag">태그</label>
+        <input id="tag" placeholder="태그를 입력해주세요." />
+        <label for="text">본문</label>
+        <textarea id="text" placeholder="본문을 입력해주세요." />
+        <div>
+          <BtnDefault>취소</BtnDefault>
+          <BtnAccent>등록</BtnAccent>
+        </div>
+      </WriteForm>
+    </StyledBoard>
+  );
+};
+
+export default Write;

--- a/src/components/button/BtnAccent.js
+++ b/src/components/button/BtnAccent.js
@@ -1,0 +1,16 @@
+import styled from "styled-components";
+
+export const BtnAccent = styled.button`
+  height: 50px;
+  padding: 0 20px;
+  border-radius: 10px;
+  font-size: 18px;
+  color: ${(props) => props.theme.bgColor};
+  background-color: ${(props) => props.theme.accentColor};
+  border: none;
+
+  &:hover {
+    background-color: ${(props) => props.theme.accentColorOpacity};
+    cursor: pointer;
+  }
+`;

--- a/src/components/button/BtnDefault.js
+++ b/src/components/button/BtnDefault.js
@@ -1,0 +1,16 @@
+import styled from "styled-components";
+
+export const BtnDefault = styled.button`
+  height: 50px;
+  padding: 0 20px;
+  border-radius: 10px;
+  font-size: 18px;
+  border: 1px solid ${(props) => props.theme.textColor};
+  color: ${(props) => props.theme.textColor};
+  background-color: ${(props) => props.theme.bgColor};
+
+  &:hover {
+    background-color: ${(props) => props.theme.bgColorOpacity};
+    cursor: pointer;
+  }
+`;

--- a/src/pages/BoardList.js
+++ b/src/pages/BoardList.js
@@ -22,7 +22,7 @@ const Main = styled.main`
   justify-content: space-around;
 `;
 
-function Board() {
+function BoardList() {
   return (
     <Container>
       <Header />
@@ -35,4 +35,4 @@ function Board() {
   );
 }
 
-export default Board;
+export default BoardList;

--- a/src/pages/BoardWrite.js
+++ b/src/pages/BoardWrite.js
@@ -1,0 +1,37 @@
+import styled from "styled-components";
+import Ads from "../components/Ads";
+import Aside from "../components/Aside";
+import Write from "../components/board/Write";
+import Header from "../components/header/Header";
+
+const Container = styled.div`
+  width: 100vw;
+  height: auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  color: ${(props) => props.theme.textColor};
+  background-color: ${(props) => props.theme.bgColor};
+`;
+
+const Main = styled.main`
+  width: 100vw;
+  display: flex;
+  justify-content: space-around;
+`;
+
+function BoardWrite() {
+  return (
+    <Container>
+      <Header />
+      <Main>
+        <Aside />
+        <Write />
+        <Ads />
+      </Main>
+    </Container>
+  );
+}
+
+export default BoardWrite;


### PR DESCRIPTION
### ♻️ refactor: 재사용을 위해 버튼 컴포넌트 분리

- 글 목록에서 생성한 버튼의 스타일을 글 작성에서도 사용하기 위해 컴포넌트로 분리하였습니다.

### ♻️ refactor: Board 페이지 이름 변경

- 우선 BoardList, BoardWrite 로 페이지를 나눴습니다.
- 추후 react-router-dom 을 활용해서 Board 페이지를 하나로 두고 다른 형태로 컴포넌트 전환해줘도 좋을 것 같습니다 (Optional)

### ✨ feat: 글 작성 컴포넌트 생성

- 글 작성 컴포넌트를 생성하였습니다.
- 글 목록 페이지에서 작성하기를 클릭하면 화면이 전환됩니다.
- parameter '/write' 로 주었습니다.
- 예시 영상

https://user-images.githubusercontent.com/101603474/197406674-43cb8885-72d7-449d-b9e4-3acfc306e1b5.mov

